### PR TITLE
Fix GH release workflow auth issue

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -17,6 +17,8 @@ jobs:
           node-version: 20
           registry-url: https://npm.pkg.github.com/
       - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - run: npm run build --if-present
       - run: npm publish
         env:


### PR DESCRIPTION
Because we're using counting-js from GH packages, the ci step in the release workflow needs to authorize using `GITHUB_TOKEN`.
This /should/ fix the issue, but I haven't tested it.