### PR TITLE
Shake

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@metal-pony/sudoku-js",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@metal-pony/sudoku-js",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@metal-pony/counting-js": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "arg": "5.0.2"
       },
       "devDependencies": {
+        "@types/jest": "^30.0.0",
         "jest": "30.4.2",
         "jest-environment-jsdom": "30.4.1",
         "jest-expect-message": "1.1.3"
@@ -654,9 +655,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1287,6 +1288,17 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
     "node_modules/@types/jsdom": {
       "version": "21.1.7",
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
@@ -1616,6 +1628,40 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "fingerprint": "node scripts/sudoku/fingerprint.js"
   },
   "devDependencies": {
+    "@types/jest": "^30.0.0",
     "jest": "30.4.2",
     "jest-environment-jsdom": "30.4.1",
     "jest-expect-message": "1.1.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metal-pony/sudoku-js",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Sudoku solver and generator module",
   "type": "module",
   "license": "MIT",

--- a/src/sudoku/Sudoku.js
+++ b/src/sudoku/Sudoku.js
@@ -1189,6 +1189,11 @@ export class Sudoku {
       }
       this._addConstraint(index, digit);
     }
+
+    if (digit === 0) {
+      this._board[index] = ALL ^ this._cellConstraints(index);
+    }
+
     return true;
   }
 

--- a/src/sudoku/Sudoku.js
+++ b/src/sudoku/Sudoku.js
@@ -960,8 +960,7 @@ export class Sudoku {
    * @returns {boolean}
    */
   equals(other) {
-    const otherBoard = other.board;
-    return this.board.every((val, i) => val === otherBoard[i]);
+    return this._digits.every((val, i) => val === other._digits[i]);
   }
 
   /**
@@ -1360,7 +1359,7 @@ export class Sudoku {
    * @returns {string}
    */
   toString() {
-    return this.board.join('').replace(/0/g, '.');
+    return this._digits.join('').replace(/0/g, '.');
   }
 
   /**
@@ -1368,8 +1367,8 @@ export class Sudoku {
    * @returns {string}
    */
   toFullString() {
-    return this._board.reduce((str, val, i) => {
-      str += isDigit(val) ? decode(val) : '.';
+    return this._digits.reduce((str, val, i) => {
+      str += ((val > 0) ? val : '.');
       str += (((((i+1)%3) === 0) && (((i+1)%9) !== 0)) ? ' | ' : '   ');
 
       if (((i+1)%9) === 0) {
@@ -1403,7 +1402,7 @@ export class Sudoku {
    */
   static toMedString(board) {
     return board.reduce((str, val, i) => {
-      str += val > 0 ? val : ' ';
+      str += ((val > 0) ? val : ' ');
       if ((((i+1)%3) === 0) && (((i+1)%9) !== 0)) {
         str += '|';
       } else {
@@ -1427,7 +1426,7 @@ export class Sudoku {
    * @returns {number[]} A copy of the normalized board.
    */
   get normalizedBoard() {
-    const copy = [...this.board];
+    const copy = [...this._digits];
     for (let i = 1; i <= DIGITS; i++) {
       const digit = copy[i - 1];
       if (digit != i) {

--- a/src/sudoku/Sudoku.js
+++ b/src/sudoku/Sudoku.js
@@ -222,15 +222,15 @@ export const cellRegion2D = (row, col) => CELL_REGIONS[row * DIGITS + col];
 
 /**
  * Returns whether an area on a Sudoku board (row, column, or region)
- * is valid given the encoded values of the cells that make up the area.
- * @param {number[]} areaVals
+ * is valid given the digits of the cells that make up the area.
+ * @param {number[]} areaDigits
  * @returns {boolean}
  */
-function isAreaValid(areaVals) {
+export function isAreaValid(areaDigits) {
   let reduced = 0;
-  const vals = areaVals.filter(isDigit);
+  const vals = areaDigits.filter(d => ((d > 0) && (d <= DIGITS)));
   for (let vi = 0; vi < vals.length; vi++) {
-    const val = vals[vi];
+    const val = encode(vals[vi]);
     if ((reduced & val) > 0) {
       return false;
     }
@@ -246,7 +246,7 @@ function isAreaValid(areaVals) {
  * @param {number[]} areaVals
  * @returns {boolean}
  */
-const isAreaFull = (areaVals) => areaVals.every(isDigit);
+const isAreaFull = (areaVals) => areaVals.every(d => (d > 0 && d <= DIGITS));
 
 class SearchNode {
   /**

--- a/src/sudoku/Sudoku.js
+++ b/src/sudoku/Sudoku.js
@@ -1270,7 +1270,7 @@ export class Sudoku {
    * @returns {number[]}
    */
   rowVals(row) {
-    return indicesFor.row[row].map((i) => this._board[i]);
+    return indicesFor.row[row].map((i) => this._digits[i]);
   }
 
   /**
@@ -1279,7 +1279,7 @@ export class Sudoku {
    * @returns {number[]}
    */
   colVals(col) {
-    return indicesFor.col[col].map((i) => this._board[i]);
+    return indicesFor.col[col].map((i) => this._digits[i]);
   }
 
   /**
@@ -1288,7 +1288,7 @@ export class Sudoku {
    * @returns {number[]}
    */
   regionVals(reg) {
-    return indicesFor.region[reg].map((i) => this._board[i]);
+    return indicesFor.region[reg].map((i) => this._digits[i]);
   }
 
   /**

--- a/src/sudoku/Sudoku.js
+++ b/src/sudoku/Sudoku.js
@@ -960,7 +960,8 @@ export class Sudoku {
    * @returns {boolean}
    */
   equals(other) {
-    return this.board.every((val, i) => val === other.board[i]);
+    const otherBoard = other.board;
+    return this.board.every((val, i) => val === otherBoard[i]);
   }
 
   /**

--- a/src/sudoku/Sudoku.js
+++ b/src/sudoku/Sudoku.js
@@ -2060,6 +2060,35 @@ export class Sudoku {
     if (diffs.length === 0) return -1;
     return diffs.reduce((acc, d) => (acc + d), 0) / diffs.length;
   }
+
+  /**
+   * Continuously removes digits from the board at random,
+   * until the board is as empty as possible without becoming unsolvable. This method
+   * modifies the current Sudoku instance.
+   *
+   * @returns {Sudoku} This Sudoku instance.
+   */
+  shake() {
+    // If this grid does not have a unique solution, return immediately.
+    if (!this.hasUniqueSolution()) return;
+
+    const clonedSudoku = new Sudoku(this);
+    shuffle(range(SPACES)).forEach((ci) => {
+      // Skip if the cell is already empty.
+      if (this._digits[ci] === 0) return;
+
+      // Attempt to remove cell on the clone.
+      clonedSudoku.setDigit(0, ci);
+      if (clonedSudoku.hasUniqueSolution()) {
+        this.setDigit(0, ci);
+      } else {
+        // Multiple solutions; revert clone state.
+        clonedSudoku.copyFrom(this);
+      }
+    });
+
+    return this;
+  }
 }
 
 export default Sudoku;

--- a/test/sudoku/Sudoku.test.js
+++ b/test/sudoku/Sudoku.test.js
@@ -1,8 +1,8 @@
 import { randomCombo } from '@metal-pony/counting-js';
-import { Sudoku } from '../../index.js';
+import { Sudoku, sudoku17 } from '../../index.js';
 import puzzles from './puzzles24.json';
 import { range, shuffle } from '../../src/util/arrays.js';
-import { SearchState } from '../../src/sudoku/Sudoku.js';
+import { SearchState, SPACES } from '../../src/sudoku/Sudoku.js';
 
 // A subset of `puzzles`, chosen at random.
 const SINGLE_SOLUTION_PUZZLES = shuffle(range(puzzles.length)).slice(0, 100).map(i => puzzles[i]);
@@ -210,6 +210,76 @@ describe('Sudoku', () => {
       expect(grid.dc2()).toBe(expected_dc2);
       // Disabled for performance.
       // expect(grid.dc3()).toBe(expected_fp3);
+    });
+  });
+
+  describe('shake', () => {
+    test('when grid is empty, does nothing', () => {
+      const grid = new Sudoku();
+      // Copy of grid to preserve original state for comparison.
+      const originalGridCopy = new Sudoku(grid);
+
+      grid.shake();
+
+      expect(grid).toStrictEqual(originalGridCopy);
+    });
+
+    test('when grid is invalid, does nothing', () => {
+      // Test with a generated config and set _isValid = false,
+      // or set the first 2 cells to the same digit.
+      const grid = Sudoku.generateConfig();
+      grid.setDigit(1, 0);
+      grid.setDigit(1, 1);
+      const originalGridCopy = new Sudoku(grid);
+      grid.shake();
+      expect(grid).toStrictEqual(originalGridCopy);
+
+      // Test with NO_SOLUTION_PUZZLES and MULTI_SOLUTION_PUZZLES
+      NO_SOLUTION_PUZZLES.forEach(p => {
+        const grid = new Sudoku(p);
+        const originalGridCopy = new Sudoku(grid);
+        grid.shake();
+        expect(grid).toStrictEqual(originalGridCopy);
+      });
+
+      MULTI_SOLUTION_PUZZLES.forEach(({ puzzleStr }) => {
+        const grid = new Sudoku(puzzleStr);
+        const originalGridCopy = new Sudoku(grid);
+        grid.shake();
+        expect(grid).toStrictEqual(originalGridCopy);
+      });
+    });
+
+    /**
+     * @param {Sudoku} grid
+     */
+    const expectGridToBeIrreducable = (grid) => {
+      for (let ci = 0; ci < SPACES; ci++) {
+        if (grid.getDigit(ci) === 0) continue;
+        const clone = new Sudoku(grid);
+        clone.setDigit(0, ci);
+        expect(clone.hasUniqueSolution()).toBe(false);
+      }
+    };
+
+    test('when grid is valid, no remaining digit can be removed', () => {
+      // Test with several puzzle from the sudoku-17 file.
+      for (let i = 0; i < 10; i++) {
+        const si = (Math.random() * sudoku17.length) | 0;
+        const grid = new Sudoku(sudoku17[si]);
+        expectGridToBeIrreducable(grid);
+      }
+
+      // Test several times with generated configs.
+      for (let i = 0; i < 10; i++) {
+        expectGridToBeIrreducable(Sudoku.generateConfig());
+      }
+
+      // Test with SINGLE_SOLUTION_PUZZLES.
+      const ENDI = Math.min(10, SINGLE_SOLUTION_PUZZLES.length);
+      for (let i = 0; i < ENDI; i++) {
+        expectGridToBeIrreducable(new Sudoku(SINGLE_SOLUTION_PUZZLES[i]));
+      }
     });
   });
 });

--- a/test/sudoku/Sudoku.test.js
+++ b/test/sudoku/Sudoku.test.js
@@ -2,7 +2,7 @@ import { randomCombo } from '@metal-pony/counting-js';
 import { Sudoku, sudoku17 } from '../../index.js';
 import puzzles from './puzzles24.json';
 import { range, shuffle } from '../../src/util/arrays.js';
-import { cellRegion, SearchState, SPACES } from '../../src/sudoku/Sudoku.js';
+import { cellRegion, isAreaValid, SearchState, SPACES } from '../../src/sudoku/Sudoku.js';
 
 // A subset of `puzzles`, chosen at random.
 const SINGLE_SOLUTION_PUZZLES = shuffle(range(puzzles.length)).slice(0, 100).map(i => puzzles[i]);
@@ -31,6 +31,31 @@ const MULTI_SOLUTION_PUZZLES = [
   { puzzleStr: '1..4..7.9......3...75.8.6143........8.43...6......4...2..1....6..8.........9.5..2', numSolutions: 3383 },
   { puzzleStr: '.2.......9.6.175..........34.....961.....5....7.9.4.......42...237.8...5....3..2.', numSolutions: 243 },
 ];
+
+describe('isAreaValid', () => {
+  describe('when areaDigits is empty or contains no nonzero digits', () => {
+    test('returns true', () => {
+      expect(isAreaValid([])).toBe(true);
+      expect(isAreaValid([0])).toBe(true);
+      expect(isAreaValid([0, 0, 0])).toBe(true);
+    });
+  });
+
+  describe('when areaDigits contains no duplicate digits', () => {
+    test('returns true', () => {
+      expect(isAreaValid([1, 2, 3])).toBe(true);
+      expect(isAreaValid([1, 2, 3, 4, 5, 6, 7, 8, 9])).toBe(true);
+      expect(isAreaValid([1, 2, 3, 4, 0, 6, 7, 8, 0])).toBe(true);
+    });
+  });
+
+  describe('when areaDigits contains duplicate digits', () => {
+    test('returns false', () => {
+      expect(isAreaValid([1, 2, 3, 4, 5, 6, 7, 8, 1])).toBe(false);
+      expect(isAreaValid([4, 0, 0, 0, 0, 0, 0, 0, 4])).toBe(false);
+    });
+  });
+});
 
 describe('SearchState', () => {
   /** @type {SearchState} */

--- a/test/sudoku/Sudoku.test.js
+++ b/test/sudoku/Sudoku.test.js
@@ -2,7 +2,7 @@ import { randomCombo } from '@metal-pony/counting-js';
 import { Sudoku, sudoku17 } from '../../index.js';
 import puzzles from './puzzles24.json';
 import { range, shuffle } from '../../src/util/arrays.js';
-import { SearchState, SPACES } from '../../src/sudoku/Sudoku.js';
+import { cellRegion, SearchState, SPACES } from '../../src/sudoku/Sudoku.js';
 
 // A subset of `puzzles`, chosen at random.
 const SINGLE_SOLUTION_PUZZLES = shuffle(range(puzzles.length)).slice(0, 100).map(i => puzzles[i]);
@@ -130,6 +130,23 @@ describe('Sudoku', () => {
       for (let n = 0; n < 10; n++) {
         expect(Sudoku.generateConfig().solutionsFlag()).toBe(1);
       }
+    });
+
+    describe('when a config has some non-intersecting digits cleared', () => {
+      test('returns 1', () => {
+        const config = Sudoku.generateConfig();
+
+        // Collect indices of cells within the diagonal regions
+        const cellsToRemove = shuffle(range(SPACES).filter(ci => {
+          const r = cellRegion(ci);
+          return (r === 0 || r === 4 || r === 8);
+        }));
+
+        cellsToRemove.forEach(ci => {
+          config.setDigit(0, ci);
+          expect(config.solutionsFlag()).toBe(1);
+        });
+      });
     });
   });
 

--- a/test/sudoku/Sudoku.test.js
+++ b/test/sudoku/Sudoku.test.js
@@ -267,18 +267,24 @@ describe('Sudoku', () => {
       for (let i = 0; i < 10; i++) {
         const si = (Math.random() * sudoku17.length) | 0;
         const grid = new Sudoku(sudoku17[si]);
+        grid.shake();
         expectGridToBeIrreducable(grid);
       }
 
       // Test several times with generated configs.
       for (let i = 0; i < 10; i++) {
-        expectGridToBeIrreducable(Sudoku.generateConfig());
+        const grid = Sudoku.generateConfig();
+        grid.shake();
+        expectGridToBeIrreducable(grid);
+        expect(grid.numEmptyCells).toBeGreaterThan(0);
       }
 
       // Test with SINGLE_SOLUTION_PUZZLES.
       const ENDI = Math.min(10, SINGLE_SOLUTION_PUZZLES.length);
       for (let i = 0; i < ENDI; i++) {
-        expectGridToBeIrreducable(new Sudoku(SINGLE_SOLUTION_PUZZLES[i]));
+        const grid = new Sudoku(SINGLE_SOLUTION_PUZZLES[i]);
+        grid.shake();
+        expectGridToBeIrreducable(grid);
       }
     });
   });


### PR DESCRIPTION
- Add `grid`shake()` method and tests.
- Added jest types package for intellisense.

- Fixes `toFullString()` which iterate over candidates data instead of digits.

Resolves #27
Resolves #28 

- `setDigit(0, ci)` now resets the cell candidates `ALL ^ this._cellConstraints(ci)`, after updating constraints.
  - Previously, `setDigit(0, ci)` resulted in removing all candidates for the cell (`_board[ci] = 0`). With no candidates for SearchNodes to test, solution search fails, leading some downstream functions (solutionsFlag, hasUniqueSolution, etc.) to fail.
