### PR TITLE
Buff tests; Patch shake()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage/
 .vscode/
 # DS_AnnoyingAsFuck_Store
 .DS_Store
+pages/

--- a/package-lock.json
+++ b/package-lock.json
@@ -3516,9 +3516,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@metal-pony/sudoku-js",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@metal-pony/sudoku-js",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "@metal-pony/counting-js": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metal-pony/sudoku-js",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Sudoku solver and generator module",
   "type": "module",
   "license": "MIT",

--- a/src/sudoku/Sudoku.js
+++ b/src/sudoku/Sudoku.js
@@ -1191,7 +1191,9 @@ export class Sudoku {
     }
 
     if (digit === 0) {
-      this._candidates[index] = ALL ^ this._cellConstraints(index);
+      // PATCHED -- Newly added logic causing incorrect solutnionsFlags
+      // this._candidates[index] = ALL ^ this._cellConstraints(index);
+      this._candidates[index] = ALL;
     }
 
     return true;
@@ -1861,7 +1863,8 @@ export class Sudoku {
    */
   solutionsFlag() {
     if (!this.isValid()) return 0;
-    if (this.numEmptyCells > (SPACES - MIN_CLUES)) return 2;
+    if (this.numEmptyCells > (SPACES - MIN_CLUES)) return 3;
+    if (BIT_COUNT_MAP[this.digitsUsed()] < 8) return 4;
 
     const search = new SearchState(this);
     while (search.numSolutions < 2 && search.advanceToSolution());
@@ -2079,6 +2082,23 @@ export class Sudoku {
     });
 
     return this;
+  }
+
+  /**
+   *
+   * @returns {number} Encoded number indicating which digits are in use in this grid.
+   */
+  digitsUsed() {
+    let ds = 0;
+    let bc = 0;
+    for (let ci = 0; ci < SPACES & bc < 9; ci++) {
+      const d = this._digits[ci];
+      if (d > 0 && (ds & ENCODER[d]) === 0) {
+        ds |= ENCODER[d];
+        bc++;
+      }
+    }
+    return ds;
   }
 }
 

--- a/src/sudoku/Sudoku.js
+++ b/src/sudoku/Sudoku.js
@@ -266,7 +266,7 @@ class SearchNode {
   pickCell() {
     this.emptyCellIndex = this.sudoku._pickEmptyCell();
     if (this.emptyCellIndex != -1) {
-      this.candidates = this.sudoku._board[this.emptyCellIndex];
+      this.candidates = this.sudoku._candidates[this.emptyCellIndex];
     }
   }
 
@@ -806,7 +806,7 @@ export class Sudoku {
 
     for (let ci = 0; ci < SPACES; ci++) {
       if (this._digits[ci]) continue;
-      this._board[ci] &= ~this._cellConstraints(ci);
+      this._candidates[ci] &= ~this._cellConstraints(ci);
     }
 
     search.init(this);
@@ -839,7 +839,7 @@ export class Sudoku {
    * @throws {Error} If the top row is not fully filled.
    */
   normalize() {
-    if (!isAreaFull(this.rowVals(0))) {
+    if (!isAreaFull(this._digits.slice(0, DIGITS))) {
       throw new Error('Top row must be fully filled before normalizing.');
     }
 
@@ -913,7 +913,7 @@ export class Sudoku {
    */
   allAntiesSolve() {
     for (let ci = 0; ci < SPACES; ci++) {
-      const originalVal = this._board[ci];
+      const originalVal = this._candidates[ci];
       const originalDigit = this._digits[ci];
       // Fail fast if there are any cells with no candidates
       if (originalVal === 0) return false;
@@ -925,7 +925,7 @@ export class Sudoku {
         this.setDigit(candidateDigit, ci); // mutates constraints
         const flag = this.solutionsFlag();
         this.setDigit(0, ci); // undo the constraints mutation
-        this._board[ci] = originalVal;
+        this._candidates[ci] = originalVal;
         this._digits[ci] = originalDigit;
         if (flag === 2) return false;
         if (flag === 1) count++;
@@ -1034,9 +1034,9 @@ export class Sudoku {
    */
   static fromState({ digits, candidates }) {
     const sudoku = new Sudoku(digits);
-    sudoku._board = [...candidates];
+    sudoku._candidates = [...candidates];
     // If any cell lacks valid candidates, mark as invalid.
-    if (sudoku._board.some((val, ci) => (~sudoku._cellConstraints(ci) & val) === 0)) {
+    if (sudoku._candidates.some((val, ci) => (~sudoku._cellConstraints(ci) & val) === 0)) {
       sudoku._isValid = false;
     }
     return sudoku;
@@ -1048,7 +1048,7 @@ export class Sudoku {
    */
   constructor(data = []) {
     /**
-     * The Sudoku board, represented as an array of bit masks, each a length of `NUM_DIGITS` bits.
+     * The sudoku board cell candidates, represented as an array of 9-bit masks.
      * The masks correspond to the candidate values for each cell, e.g.:
      * - `0b000000001` = 1
      * - `0b000000010` = 2
@@ -1057,7 +1057,7 @@ export class Sudoku {
      * - `0b111111111` = all candidates (1 - 9)
      * @type {number[]}
      */
-    this._board;
+    this._candidates;
 
     /** @type {number[]} */
     this._digits;
@@ -1090,20 +1090,20 @@ export class Sudoku {
     this._isValid = true;
 
     if (data instanceof Sudoku) {
-      this._board = [...data._board];
+      this._candidates = [...data._candidates];
       this._digits = [...data._digits];
       this._constraints = [...data._constraints];
       this._numEmptyCells = data._numEmptyCells;
       this._isValid = data._isValid;
     } else if (typeof data === 'string') {
       const parsed = Sudoku.fromString(data);
-      this._board = [...parsed._board];
+      this._candidates = [...parsed._candidates];
       this._digits = [...parsed._digits];
       this._constraints = [...parsed._constraints];
       this._numEmptyCells = parsed._numEmptyCells;
       this._isValid = parsed._isValid;
     } else if (Array.isArray(data)) {
-      this._board = Array(SPACES).fill(ALL);
+      this._candidates = Array(SPACES).fill(ALL);
       this._digits = Array(SPACES).fill(0);
       this._constraints = Array(DIGITS).fill(0);
       if (data.length === SPACES) this.setBoard(data);
@@ -1118,7 +1118,7 @@ export class Sudoku {
    * @returns This sudoku for convenience.
    */
   copyFrom(other) {
-    this._board = [...other._board];
+    this._candidates = [...other._candidates];
     this._digits = [...other._digits];
     this._constraints = [...other._constraints];
     this._numEmptyCells = other._numEmptyCells;
@@ -1137,7 +1137,7 @@ export class Sudoku {
     for (let r = 0; r < DIGITS; r++) {
       const start = r * DIGITS;
       const end = start + DIGITS;
-      const rowValues = this.board.slice(start, end);
+      const rowValues = this._digits.slice(start, end);
       boardRows.push(rowValues);
     }
     return boardRows;
@@ -1175,7 +1175,7 @@ export class Sudoku {
     if (prevDigit === digit) return false;
 
     this._digits[index] = digit;
-    this._board[index] = ENCODER[digit];
+    this._candidates[index] = ENCODER[digit];
 
     if (prevDigit > 0) {
       this._numEmptyCells++;
@@ -1191,7 +1191,7 @@ export class Sudoku {
     }
 
     if (digit === 0) {
-      this._board[index] = ALL ^ this._cellConstraints(index);
+      this._candidates[index] = ALL ^ this._cellConstraints(index);
     }
 
     return true;
@@ -1211,10 +1211,7 @@ export class Sudoku {
 
     // TODO Maybe we don't need to do this
     // The constructor(data == Array) handles this
-    this._numEmptyCells = SPACES;
-    this._board.fill(ALL);
-    this._digits.fill(0);
-    this._constraints.fill(0);
+    this.clear();
 
     digits.forEach((digit, i) => {
       if (typeof digit !== 'number') {
@@ -1246,24 +1243,14 @@ export class Sudoku {
    * @returns {number[]}
    */
   getCandidates(cellIndex) {
-    return CANDIDATE_DECODINGS[this._board[cellIndex]];
+    return CANDIDATE_DECODINGS[this._candidates[cellIndex]];
   }
 
   /**
    * Clears all values and clues on the board. The result will be completely blank.
    */
   clear() {
-    this._board.fill(ALL);
-    this._digits.fill(0);
-    this._constraints.fill(0);
-    this._numEmptyCells = SPACES;
-  }
-
-  /**
-   * Resets the board to its initial clues.
-   */
-  reset() {
-    this._board.fill(ALL);
+    this._candidates.fill(ALL);
     this._digits.fill(0);
     this._constraints.fill(0);
     this._numEmptyCells = SPACES;
@@ -1351,7 +1338,7 @@ export class Sudoku {
    */
   isNormal() {
     for (let ci = 0; ci < DIGITS; ci++) {
-      const digit = decode(this._board[ci]);
+      const digit = decode(this._candidates[ci]);
       if (digit !== (ci + 1)) {
         return false;
       }
@@ -1509,14 +1496,14 @@ export class Sudoku {
     const abEncoded = (aEncoded | bEncoded);
     for (let ci = 0; ci < SPACES; ci++) {
       // Skip if cell has both candidates
-      if ((this._board[ci] & abEncoded) === abEncoded) continue;
+      if ((this._candidates[ci] & abEncoded) === abEncoded) continue;
 
-      if ((this._board[ci] & aEncoded) > 0) {
-        this._board[ci] &= ~aEncoded;
-        this._board[ci] |= bEncoded;
-      } else if ((this._board[ci] & bEncoded) > 0) {
-        this._board[ci] &= ~bEncoded;
-        this._board[ci] |= aEncoded;
+      if ((this._candidates[ci] & aEncoded) > 0) {
+        this._candidates[ci] &= ~aEncoded;
+        this._candidates[ci] |= bEncoded;
+      } else if ((this._candidates[ci] & bEncoded) > 0) {
+        this._candidates[ci] &= ~bEncoded;
+        this._candidates[ci] |= aEncoded;
       }
     }
   }
@@ -1552,7 +1539,7 @@ export class Sudoku {
    * Note: board constraints will be out of sync.
    */
   reflectOverHorizontal() {
-    reflectOverHorizontal(this._board, DIGITS);
+    reflectOverHorizontal(this._candidates, DIGITS);
     reflectOverHorizontal(this._digits, DIGITS);
   }
 
@@ -1562,7 +1549,7 @@ export class Sudoku {
    * Note: board constraints will be out of sync.
    */
   reflectOverVertical() {
-    reflectOverVertical(this._board, DIGITS);
+    reflectOverVertical(this._candidates, DIGITS);
     reflectOverVertical(this._digits, DIGITS);
   }
 
@@ -1572,7 +1559,7 @@ export class Sudoku {
    * Note: board constraints will be out of sync.
    */
   reflectOverDiagonal() {
-    reflectOverDiagonal(this._board);
+    reflectOverDiagonal(this._candidates);
     reflectOverDiagonal(this._digits);
   }
 
@@ -1582,7 +1569,7 @@ export class Sudoku {
    * Note: board constraints will be out of sync.
    */
   reflectOverAntidiagonal() {
-    reflectOverAntiDiagonal(this._board);
+    reflectOverAntiDiagonal(this._candidates);
     reflectOverAntiDiagonal(this._digits);
   }
 
@@ -1592,7 +1579,7 @@ export class Sudoku {
    * Note: board constraints will be out of sync.
    */
   rotate90() {
-    rotateArr90(this._board);
+    rotateArr90(this._candidates);
     rotateArr90(this._digits);
   }
 
@@ -1612,9 +1599,9 @@ export class Sudoku {
 
     const N = DIGITS * 3;
     const bands = [
-      this._board.slice(0, N),
-      this._board.slice(N, N*2),
-      this._board.slice(N*2, N*3)
+      this._candidates.slice(0, N),
+      this._candidates.slice(N, N*2),
+      this._candidates.slice(N*2, N*3)
     ];
     const digits = [
       this._digits.slice(0, N),
@@ -1624,7 +1611,7 @@ export class Sudoku {
 
     swap(bands, b1, b2);
     swap(digits, b1, b2);
-    this._board = bands.flat();
+    this._candidates = bands.flat();
     this._digits = digits.flat();
   }
 
@@ -1645,11 +1632,11 @@ export class Sudoku {
     }
 
     const N = DIGITS;
-    const rows = range(DIGITS).map(i => this._board.slice(N*i, N*(i+1)));
+    const rows = range(DIGITS).map(i => this._candidates.slice(N*i, N*(i+1)));
     const digitRows = range(DIGITS).map(i => this._digits.slice(N*i, N*(i+1)));
     swap(rows, r1, r2);
     swap(digitRows, r1, r2);
-    this._board = rows.flat();
+    this._candidates = rows.flat();
     this._digits = digitRows.flat();
   }
 
@@ -1671,9 +1658,9 @@ export class Sudoku {
 
     let temp;
     for (let r = 0; r < DIGITS; r++) {
-      temp = this._board[r * DIGITS + c1];
-      this._board[r * DIGITS + c1] = this._board[r * DIGITS + c2];
-      this._board[r * DIGITS + c2] = temp;
+      temp = this._candidates[r * DIGITS + c1];
+      this._candidates[r * DIGITS + c1] = this._candidates[r * DIGITS + c2];
+      this._candidates[r * DIGITS + c2] = temp;
 
       temp = this._digits[r * DIGITS + c1];
       this._digits[r * DIGITS + c1] = this._digits[r * DIGITS + c2];
@@ -1711,7 +1698,7 @@ export class Sudoku {
     this._isValid = true;
     for (let i = 0; i < SPACES; i++) {
       if (this._digits[i] > 0) {
-        if (this._cellConstraints(i) & this._board[i]) {
+        if (this._cellConstraints(i) & this._candidates[i]) {
           this._isValid = false;
         }
         this._addConstraint(i, this._digits[i]);
@@ -1725,7 +1712,7 @@ export class Sudoku {
   _resetEmptyCells() {
     for (let i = 0; i < SPACES; i++) {
       if (this._digits[i] === 0) {
-        this._board[i] = ALL;
+        this._candidates[i] = ALL;
       }
     }
   };
@@ -1765,22 +1752,22 @@ export class Sudoku {
    */
   _reduceCell(ci) {
     if (this._digits[ci] > 0) return false;
-    const originalCandidates = this._board[ci];
-    this._board[ci] &= ~this._cellConstraints(ci);
+    const originalCandidates = this._candidates[ci];
+    this._candidates[ci] &= ~this._cellConstraints(ci);
 
     // If there are no more candidates for the cell, the board is invalid.
-    if (this._board[ci] <= 0) {
+    if (this._candidates[ci] <= 0) {
       this._isValid = false;
       this.setDigit(0, ci);
       return false;
     }
 
-    if (isDigit(this._board[ci])) {
-      this.setDigit(decode(this._board[ci]), ci);
+    if (isDigit(this._candidates[ci])) {
+      this.setDigit(decode(this._candidates[ci]), ci);
     }
 
     // Propagate to neighboring cells if there was any reduction to the cell.
-    if (this._board[ci] < originalCandidates) {
+    if (this._candidates[ci] < originalCandidates) {
       for (let ni of CELL_NEIGHBORS[ci]) {
         if (this._digits[ni] === 0) this._reduceCell(ni);
       }
@@ -1794,10 +1781,10 @@ export class Sudoku {
    * @returns {number} The unique candidate digit; or 0 if none.
    */
   _checkHiddenSingles(ci) {
-    for (let candidate of CANDIDATES[this._board[ci]]) {
+    for (let candidate of CANDIDATES[this._candidates[ci]]) {
       let unique = true;
       for (let ni of ROW_NEIGHBORS[ci]) {
-        if (this._board[ni] & candidate) {
+        if (this._candidates[ni] & candidate) {
           unique = false;
           break;
         }
@@ -1806,7 +1793,7 @@ export class Sudoku {
 
       unique = true;
       for (let ni of COL_NEIGHBORS[ci]) {
-        if (this._board[ni] & candidate) {
+        if (this._candidates[ni] & candidate) {
           unique = false;
           break;
         }
@@ -1815,7 +1802,7 @@ export class Sudoku {
 
       unique = true;
       for (let ni of REGION_NEIGHBORS[ci]) {
-        if (this._board[ni] & candidate) {
+        if (this._candidates[ni] & candidate) {
           unique = false;
           break;
         }
@@ -1839,7 +1826,7 @@ export class Sudoku {
     let _minimums = [];
     for (let ci = 0; ci < SPACES; ci++) {
       if (this._digits[ci] === 0) {
-        const numCandidates = BIT_COUNT_MAP[this._board[ci]];
+        const numCandidates = BIT_COUNT_MAP[this._candidates[ci]];
         if (numCandidates < minNumCandidates) {
           minNumCandidates = numCandidates;
           _minimums = [ci];
@@ -2035,7 +2022,7 @@ export class Sudoku {
       // Get all empty cells of minimum candidates
       let minNumCandidates = DIGITS + 1;
       let candyBucket = [];
-      sudoku._board.forEach((candidates, ci) => {
+      sudoku._candidates.forEach((candidates, ci) => {
         const numCandidates = BIT_COUNT_MAP[candidates];
         if (numCandidates > 1) {
           if (numCandidates < minNumCandidates) {
@@ -2049,7 +2036,7 @@ export class Sudoku {
 
       // For each empty cell collected, create nodes for each candidate
       candyBucket.forEach(emptyCi => {
-        CANDIDATE_DECODINGS[sudoku._board[emptyCi]].forEach(digit => {
+        CANDIDATE_DECODINGS[sudoku._candidates[emptyCi]].forEach(digit => {
           const nextSudoku = new Sudoku(sudoku);
           nextSudoku.setDigit(digit, emptyCi);
           nextSudoku._reduce();

--- a/test/sudoku/Sudoku.test.js
+++ b/test/sudoku/Sudoku.test.js
@@ -4,6 +4,21 @@ import puzzles from './puzzles24.json';
 import { range, shuffle } from '../../src/util/arrays.js';
 import { cellRegion, DIGITS, isAreaValid, SearchState, SPACES } from '../../src/sudoku/Sudoku.js';
 
+/**
+ * Get a random number from 0 to upper (exclusive).
+ * @param {number} upper
+ * @returns {number}
+ */
+const rand = (upper) => ((Math.random() * upper) | 0);
+
+
+/**
+ * Get a random sudoku17 puzzle.
+ * @returns {Sudoku}
+ */
+const randomSudoku17 = () => new Sudoku(sudoku17[rand(sudoku17.length)]);
+
+
 // A subset of `puzzles`, chosen at random.
 const SINGLE_SOLUTION_PUZZLES = shuffle(range(puzzles.length)).slice(0, 100).map(i => puzzles[i]);
 
@@ -322,36 +337,30 @@ describe('Sudoku', () => {
   });
 
   describe('solutionsFlag', () => {
-    test('returns 2 for empty puzzles', () => {
-      expect(new Sudoku().solutionsFlag()).toBe(2);
-    });
-
-    test('returns 1 for valid puzzles', () => {
-      SINGLE_SOLUTION_PUZZLES.forEach(p => {
-        expect(new Sudoku(p).solutionsFlag()).toBe(1);
-      });
-    });
-
     test('returns 0 for puzzles with no solutions', () => {
       NO_SOLUTION_PUZZLES.forEach(p => {
         expect(new Sudoku(p).solutionsFlag()).toBe(0);
       });
     });
 
-    test('returns 2 for puzzles with multiple solutions', () => {
-      MULTI_SOLUTION_PUZZLES.forEach(({ puzzleStr }) => {
-        expect(new Sudoku(puzzleStr).solutionsFlag()).toBe(2);
+    describe('returns 1', () => {
+      test('for generated configs', () => {
+        for (let n = 0; n < 10; n++) {
+          expect(Sudoku.generateConfig().solutionsFlag()).toBe(1);
+        }
       });
-    });
 
-    test('returns 1 for generated configs', () => {
-      for (let n = 0; n < 10; n++) {
-        expect(Sudoku.generateConfig().solutionsFlag()).toBe(1);
-      }
-    });
+      test('for valid puzzles', () => {
+        SINGLE_SOLUTION_PUZZLES.forEach(p => {
+          expect(new Sudoku(p).solutionsFlag()).toBe(1);
+        });
 
-    describe('when a config has some non-intersecting digits cleared', () => {
-      test('returns 1', () => {
+        for (let n = 0; n < 10; n++) {
+          expect(randomSudoku17().solutionsFlag()).toBe(1);
+        }
+      });
+
+      test('when a config has some non-intersecting digits cleared', () => {
         const config = Sudoku.generateConfig();
 
         // Collect indices of cells within the diagonal regions
@@ -365,6 +374,25 @@ describe('Sudoku', () => {
           expect(config.solutionsFlag()).toBe(1);
         });
       });
+    });
+
+    test('returns 2 for puzzles with multiple solutions', () => {
+      MULTI_SOLUTION_PUZZLES.forEach(({ puzzleStr }) => {
+        expect(new Sudoku(puzzleStr).solutionsFlag()).toBe(2);
+      });
+    });
+
+    test('returns 3 for puzzles with fewer than 17 clues', () => {
+      for (let n = 0; n < 20; n++) {
+        const s17 = randomSudoku17();
+        for (let ci = 0; ci < SPACES; ci++) {
+          if (s17.getDigit(ci) > 0) {
+            const clone = new Sudoku(s17);
+            clone.setDigit(0, ci);
+            expect(clone.solutionsFlag()).toBe(3);
+          }
+        }
+      }
     });
   });
 
@@ -483,6 +511,7 @@ describe('Sudoku', () => {
           const si = (Math.random() * sudoku17.length) | 0;
           const grid = new Sudoku(sudoku17[si]);
           grid.shake();
+          expect(grid.solutionsFlag()).toBe(1);
           expectGridToBeIrreducable(grid);
         }
 
@@ -490,6 +519,8 @@ describe('Sudoku', () => {
         for (let i = 0; i < 10; i++) {
           const grid = Sudoku.generateConfig();
           grid.shake();
+          expect(grid.solutionsFlag()).toBe(1);
+          expect(new Sudoku(grid.toString()).solutionsFlag()).toBe(1);
           expectGridToBeIrreducable(grid);
           expect(grid.numEmptyCells).toBeGreaterThan(0);
         }
@@ -499,6 +530,7 @@ describe('Sudoku', () => {
         for (let i = 0; i < ENDI; i++) {
           const grid = new Sudoku(SINGLE_SOLUTION_PUZZLES[i]);
           grid.shake();
+          expect(grid.solutionsFlag()).toBe(1);
           expectGridToBeIrreducable(grid);
         }
       });
@@ -508,6 +540,7 @@ describe('Sudoku', () => {
         for (let i = 0; i < 10; i++) {
           const grid = Sudoku.generateConfig();
           grid.shake();
+          expect(grid.solutionsFlag()).toBe(1);
           expect(grid.hasUniqueSolution()).toBe(true);
         }
       });

--- a/test/sudoku/Sudoku.test.js
+++ b/test/sudoku/Sudoku.test.js
@@ -2,7 +2,7 @@ import { randomCombo } from '@metal-pony/counting-js';
 import { Sudoku, sudoku17 } from '../../index.js';
 import puzzles from './puzzles24.json';
 import { range, shuffle } from '../../src/util/arrays.js';
-import { cellRegion, isAreaValid, SearchState, SPACES } from '../../src/sudoku/Sudoku.js';
+import { cellRegion, DIGITS, isAreaValid, SearchState, SPACES } from '../../src/sudoku/Sudoku.js';
 
 // A subset of `puzzles`, chosen at random.
 const SINGLE_SOLUTION_PUZZLES = shuffle(range(puzzles.length)).slice(0, 100).map(i => puzzles[i]);
@@ -112,6 +112,199 @@ describe('SearchState', () => {
 });
 
 describe('Sudoku', () => {
+  describe('static', () => {
+    describe('validateStr', () => {
+      describe('returns false', () => {
+        test('when the string is not given', () => {
+          expect(Sudoku.validateStr()).toBe(false);
+          expect(Sudoku.validateStr(null)).toBe(false);
+          expect(Sudoku.validateStr(undefined)).toBe(false);
+        });
+
+        test('when str is not a string', () => {
+          expect(Sudoku.validateStr(123)).toBe(false);
+          expect(Sudoku.validateStr({})).toBe(false);
+          expect(Sudoku.validateStr(['meow'])).toBe(false);
+        });
+
+        test('when str is long', () => {
+          expect(Sudoku.validateStr('.'.repeat(SPACES + 1))).toBe(false);
+        });
+
+        test('when expanded str is not the correct length', () => {
+          expect(Sudoku.validateStr('--------')).toBe(false);
+          expect(Sudoku.validateStr('.'.repeat(SPACES - 1))).toBe(false);
+        });
+
+        test('when str contains invalid characters', () => {
+          expect(Sudoku.validateStr('a'.repeat(SPACES))).toBe(false);
+          expect(Sudoku.validateStr('1'.repeat(SPACES - 1) + 'A')).toBe(false);
+        });
+      });
+
+      describe('returns true', () => {
+        test('when str is correct length containing only numbers and dots', () => {
+          const validStr = '123456789'.repeat(9);
+          expect(Sudoku.validateStr(validStr)).toBe(true);
+
+          [
+            ...SINGLE_SOLUTION_PUZZLES,
+            ...NO_SOLUTION_PUZZLES,
+            ...(MULTI_SOLUTION_PUZZLES.map(p => p.puzzleStr))
+          ].forEach(p => {
+            expect(Sudoku.validateStr(p)).toBe(true);
+          });
+        });
+
+        test('when str expands to correct length containing only numbers and dots', () => {
+          const validStrs = [
+            '.'.repeat(72) + '-',
+            '-' + '.'.repeat(72),
+            '1' + '.'.repeat(71) + '-',
+            '-' + '1' + '.'.repeat(71),
+            '1' + '.'.repeat(70) + '-1',
+            '1' + '.'.repeat(70) + '-9',
+          ];
+
+          validStrs.forEach(str => {
+            expect(Sudoku.validateStr(str)).toBe(true);
+          });
+        });
+
+        test('the str does not necessarily need to represent a valid sudoku', () => {
+          expect(Sudoku.validateStr('1'.repeat(SPACES))).toBe(true);
+        });
+      });
+    });
+
+    describe('fromString', () => {
+      describe('when str is invalid in any way', () => {
+        test('throws error', () => {
+          // Invalid because of length
+          expect(() => Sudoku.fromString('.'.repeat(SPACES - 1))).toThrow();
+
+          // Invalid because str did not expand to correct length
+          expect(() => Sudoku.fromString('1' + '.'.repeat(70) + '-')).toThrow();
+          expect(() => Sudoku.fromString('1' + '.'.repeat(72) + '-')).toThrow();
+
+          // Invalid because of invalid characters
+          expect(() => Sudoku.fromString('1'.repeat(SPACES - 1) + 'A')).toThrow();
+
+          // Invalid because of invalid characters after expansion
+          expect(() => Sudoku.fromString('-' + '.'.repeat(71) + '!')).toThrow();
+        });
+      });
+
+      describe('when str represents a grid', () => {
+        test('returns a grid with the correct digits set', () => {
+          const puzzleStr = '123456789'.repeat(9);
+          const grid = Sudoku.fromString(puzzleStr);
+          expect(grid.toString()).toBe(puzzleStr);
+        });
+      });
+    });
+
+    describe('generateConfig', () => {
+      test('is full and solved', () => {
+        for (let n = 0; n < 10; n++) {
+          const config = Sudoku.generateConfig();
+          expect(config.numEmptyCells).toBe(0);
+          expect(config.isValid()).toBe(true);
+          expect(config.isFull()).toBe(true);
+          expect(config.isSolved()).toBe(true);
+          expect(config.solutionsFlag()).toBe(1);
+        }
+      });
+    });
+
+    test('generatePuzzle2', () => {
+      for (let numClues = 81; numClues >= 24; numClues--) {
+        const puzzle = Sudoku.generatePuzzle2({ numClues });
+        expect(puzzle.numEmptyCells).toBe(81 - numClues);
+        expect(puzzle.solutionsFlag()).toBe(1);
+      }
+    });
+  });
+
+  describe('setBoard', () => {
+    describe('throws error', () => {
+      test('when digits is incorrect length', () => {
+        expect(() => new Sudoku().setBoard([])).toThrow();
+        expect(() => new Sudoku().setBoard([1, 2, 3])).toThrow();
+        expect(() => new Sudoku().setBoard(Array(SPACES - 1).fill(0))).toThrow();
+        expect(() => new Sudoku().setBoard(Array(SPACES + 1).fill(0))).toThrow();
+      });
+
+      test('when any element is not a number', () => {
+        const digits = Array(SPACES).fill(0);
+        digits[0] = 'x';
+        expect(() => new Sudoku().setBoard(digits)).toThrow();
+      });
+
+      test('when any element is out of bounds', () => {
+        const digits = Array(SPACES).fill(0);
+        digits[0] = 10;
+        expect(() => new Sudoku().setBoard(digits)).toThrow();
+      });
+    });
+
+    test('sets the board digits appropriately', () => {
+      const digits = Array(SPACES).fill(0);
+      digits[0] = 5;
+      digits[80] = 9;
+      const grid = new Sudoku();
+      grid.setBoard(digits);
+      expect(grid.board).toEqual(digits);
+      expect(grid.numEmptyCells).toBe(79);
+      expect(grid.isValid()).toBe(true);
+    });
+
+    describe('-integration-', () => {
+      describe('when data represents a valid grid', () => {
+        test('grid is solvable and has correct properties', () => {
+          // Pull from puzzles24
+          SINGLE_SOLUTION_PUZZLES.forEach(p => {
+            const digits = p.split('').map(c => (c === '.' ? 0 : Number(c)));
+            const grid = new Sudoku();
+            grid.setBoard(digits);
+            expect(grid.isValid()).toBe(true);
+            expect(grid.isFull()).toBe(false);
+            expect(grid.isSolved()).toBe(false);
+            expect(grid.numEmptyCells).toBe(81 - 24);
+            expect(grid.solutionsFlag()).toBe(1);
+          });
+
+          // Pull from a subset of sudoku17
+          const sudoku17Subset = [];
+          for (let i = 0; i < 20; i++) {
+            const si = (Math.random() * sudoku17.length) | 0;
+            sudoku17Subset.push(sudoku17[si]);
+          }
+          sudoku17Subset.forEach(p => {
+            const digits = p.split('').map(c => (c === '.' ? 0 : Number(c)));
+            const grid = new Sudoku();
+            grid.setBoard(digits);
+            expect(grid.isValid()).toBe(true);
+            expect(grid.isFull()).toBe(false);
+            expect(grid.isSolved()).toBe(false);
+            expect(grid.numEmptyCells).toBe(81 - 17);
+            expect(grid.solutionsFlag()).toBe(1);
+          });
+        });
+
+        test('board returns array identical to the given digits', () => {
+          const digits = Array(SPACES).fill(0);
+          digits[0] = 7;
+          digits[4] = 3;
+          const grid = new Sudoku();
+          grid.setBoard(digits);
+          expect(grid.board).toEqual(digits);
+          expect(grid.board).not.toBe(digits);
+        });
+      });
+    });
+  });
+
   describe('solutionCount', () => {
     test('finds the expected number of solutions', () => {
       SINGLE_SOLUTION_PUZZLES.forEach(p => {
@@ -175,27 +368,6 @@ describe('Sudoku', () => {
     });
   });
 
-  describe('generateConfig', () => {
-    test('is full and solved', () => {
-      for (let n = 0; n < 10; n++) {
-        const config = Sudoku.generateConfig();
-        expect(config.numEmptyCells).toBe(0);
-        expect(config.isValid()).toBe(true);
-        expect(config.isFull()).toBe(true);
-        expect(config.isSolved()).toBe(true);
-        expect(config.solutionsFlag()).toBe(1);
-      }
-    });
-  });
-
-  test('generatePuzzle2', () => {
-    for (let numClues = 81; numClues >= 24; numClues--) {
-      const puzzle = Sudoku.generatePuzzle2({ numClues });
-      expect(puzzle.numEmptyCells).toBe(81 - numClues);
-      expect(puzzle.solutionsFlag()).toBe(1);
-    }
-  });
-
   describe('fingerprint', () => {
     const gridStr = '218574639573896124469123578721459386354681792986237415147962853695318247832745961';
     const expected_dc2 = '9:9:7:4:2:3::16';
@@ -251,7 +423,7 @@ describe('Sudoku', () => {
       }
       expect(grid.dc2()).toBe(expected_dc2);
       // Disabled for performance.
-      // expect(grid.dc3()).toBe(expected_fp3);
+      // expect(grid.dc3()).toBe(expected_dc3);
     });
   });
 
@@ -304,30 +476,41 @@ describe('Sudoku', () => {
       }
     };
 
-    test('when grid is valid, no remaining digit can be removed', () => {
-      // Test with several puzzle from the sudoku-17 file.
-      for (let i = 0; i < 10; i++) {
-        const si = (Math.random() * sudoku17.length) | 0;
-        const grid = new Sudoku(sudoku17[si]);
-        grid.shake();
-        expectGridToBeIrreducable(grid);
-      }
+    describe('when grid is valid', () => {
+      test('no remaining digit can be removed', () => {
+        // Test with several puzzle from the sudoku-17 file.
+        for (let i = 0; i < 10; i++) {
+          const si = (Math.random() * sudoku17.length) | 0;
+          const grid = new Sudoku(sudoku17[si]);
+          grid.shake();
+          expectGridToBeIrreducable(grid);
+        }
 
-      // Test several times with generated configs.
-      for (let i = 0; i < 10; i++) {
-        const grid = Sudoku.generateConfig();
-        grid.shake();
-        expectGridToBeIrreducable(grid);
-        expect(grid.numEmptyCells).toBeGreaterThan(0);
-      }
+        // Test several times with generated configs.
+        for (let i = 0; i < 10; i++) {
+          const grid = Sudoku.generateConfig();
+          grid.shake();
+          expectGridToBeIrreducable(grid);
+          expect(grid.numEmptyCells).toBeGreaterThan(0);
+        }
 
-      // Test with SINGLE_SOLUTION_PUZZLES.
-      const ENDI = Math.min(10, SINGLE_SOLUTION_PUZZLES.length);
-      for (let i = 0; i < ENDI; i++) {
-        const grid = new Sudoku(SINGLE_SOLUTION_PUZZLES[i]);
-        grid.shake();
-        expectGridToBeIrreducable(grid);
-      }
+        // Test with SINGLE_SOLUTION_PUZZLES.
+        const ENDI = Math.min(10, SINGLE_SOLUTION_PUZZLES.length);
+        for (let i = 0; i < ENDI; i++) {
+          const grid = new Sudoku(SINGLE_SOLUTION_PUZZLES[i]);
+          grid.shake();
+          expectGridToBeIrreducable(grid);
+        }
+      });
+
+      test('resulting grid is solvable', () => {
+        // Test several times with generated configs.
+        for (let i = 0; i < 10; i++) {
+          const grid = Sudoku.generateConfig();
+          grid.shake();
+          expect(grid.hasUniqueSolution()).toBe(true);
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
Patches #30 

- Renamed `_board` -> `_candidates` to better match the variable names in the java version.
- Added tests for slightly better coverage; organized a few as well.
- Patched a potential bug causing `shake()` to remove too many clues.

```js
config = Sudoku.generateConfig()
// Sudoku {_numEmptyCells: 0, _isValid: true, _candidates: Array(81), _digits: Array(81), _constraints: Array(9)}
config.toString()
// '163987542479253816825164973912635784586741329347829165694318257758492631231576498'
shaken = config.shake()
// Sudoku {_numEmptyCells: 57, _isValid: true, _candidates: Array(81), _digits: Array(81), _constraints: Array(9)}
config.toString()
// '....8....4.9.53....2..6.97.9........58.7....9....2..6.69.....57.58...........64..'
config.solutionsFlag()
// 1
shaken.solutionsFlag()
// 1
new Sudoku(config.toString()).solutionsFlag()
// 1
```