### PR TITLE
Assorted refs

### DIFF
--- a/src/sudoku/Sudoku.js
+++ b/src/sudoku/Sudoku.js
@@ -1575,6 +1575,8 @@ export class Sudoku {
       cols.push({ i, j: (Math.random() * (i+1)) | 0 });
     }
 
+    const rotations = ((Math.random() * 4) | 0);
+
     /** @type {number[]} */
     const order = [...shuffle(DIGIT_BAG)];
 
@@ -1586,6 +1588,7 @@ export class Sudoku {
       stacks.forEach(s => { sudoku.swapStacks(s.i, s.j); });
       rows.forEach(r => { sudoku.swapStacks(r.i, r.j); });
       cols.forEach(c => { sudoku.swapStacks(c.i, c.j); });
+      for (let r = 0; r < rotations; r++) sudoku.rotate90();
       sudoku.swapAllDigits(order);
     };
   }

--- a/src/sudoku/Sudoku.js
+++ b/src/sudoku/Sudoku.js
@@ -444,6 +444,109 @@ export class SearchState {
  */
 export class Sudoku {
   /**
+   * Swaps the given bands by index (0, 1, or 2).
+   * @param {number[]} arr
+   * @param {number} band1
+   * @param {number} band2
+   * @returns {number[]}
+   */
+  static swapBands(arr, band1, band2) {
+    const b1 = band1 % 3;
+    const b2 = band2 % 3;
+    if (b1 === b2) return;
+
+    const band1Start = 27 * b1;
+    const band2Start = 27 * b2;
+    let temp;
+    for (let i = 0; i < 27; i++) {
+      temp = arr[band1Start + i];
+      arr[band1Start + i] = arr[band2Start + i];
+      arr[band2Start + i] = temp;
+    }
+
+    return arr;
+  }
+
+  /**
+   * Swaps the given rows by index (0 through 8).
+   * @param {number[]} arr
+   * @param {number} row1
+   * @param {number} row2
+   * @returns {number[]}
+   */
+  static swapRows(arr, row1, row2) {
+    const r1 = row1 % DIGITS;
+    const r2 = row2 % DIGITS;
+    if (r1 === r2) return;
+    if (((r1/3)|0) !== ((r2/3)|0)) throw Error('rows must be in the same band');
+
+    const r1Start = DIGITS * r1;
+    const r2Start = DIGITS * r2;
+    let temp;
+    for (let i = 0; i < DIGITS; i++) {
+      temp = arr[r1Start + i];
+      arr[r1Start + i] = arr[r2Start + i];
+      arr[r2Start + i] = temp;
+    }
+
+    return arr;
+  }
+
+  /**
+   * Swaps the given columns by index (0 through 8).
+   * @param {number[]} arr
+   * @param {number} col1
+   * @param {number} col2
+   * @returns {number[]}
+   */
+  static swapColumns(arr, col1, col2) {
+    const c1 = col1 % DIGITS;
+    const c2 = col2 % DIGITS;
+    if (c1 === c2) return;
+    if (((c1/3)|0) !== ((c2/3)|0)) throw Error(`columns must be in the same stack (${col1}, ${col2})`);
+
+    let temp;
+    for (let i = 0; i < SPACES; i+=DIGITS) {
+      temp = arr[i + c1];
+      arr[i + c1] = arr[i + c2];
+      arr[i + c2] = temp;
+    }
+
+    return arr;
+  }
+
+  /**
+   * Swaps the given stacks by index (0, 1, or 2).
+   * @param {number[]} arr
+   * @param {number} stack1
+   * @param {number} stack2
+   * @returns {number[]}
+   */
+  static swapStacks(arr, stack1, stack2) {
+    const s1 = stack1 % 3;
+    const s2 = stack2 % 3;
+    if (s1 === s2) return;
+
+    const col1Start = s1 * 3;
+    const col2Start = s2 * 3;
+    let temp;
+
+    for (let row = 0; row < DIGITS; row++) {
+      const rowOffset = row * DIGITS;
+      for (let col = 0; col < 3; col++) {
+        const idx1 = rowOffset + col1Start + col;
+        const idx2 = rowOffset + col2Start + col;
+
+        temp = arr[idx1];
+        arr[idx1] = arr[idx2];
+        arr[idx2] = temp;
+      }
+    }
+
+    return arr;
+  }
+
+  /**
    * Determines whether the given string represents a sudoku board, i.e. the
    * string is of proper length and contains only digits.
    *
@@ -1610,28 +1713,8 @@ export class Sudoku {
    * @param {number} band2
    */
   swapBands(band1, band2) {
-    const b1 = band1 % 3;
-    const b2 = band2 % 3;
-    if (b1 === b2) {
-      return;
-    }
-
-    const N = DIGITS * 3;
-    const bands = [
-      this._candidates.slice(0, N),
-      this._candidates.slice(N, N*2),
-      this._candidates.slice(N*2, N*3)
-    ];
-    const digits = [
-      this._digits.slice(0, N),
-      this._digits.slice(N, N*2),
-      this._digits.slice(N*2, N*3),
-    ];
-
-    swap(bands, b1, b2);
-    swap(digits, b1, b2);
-    this._candidates = bands.flat();
-    this._digits = digits.flat();
+    Sudoku.swapBands(this._digits, band1, band2);
+    Sudoku.swapBands(this._candidates, band1, band2);
   }
 
   /**
@@ -1644,19 +1727,8 @@ export class Sudoku {
    * @param {number} row2
    */
   swapRows(row1, row2) {
-    const r1 = row1 % DIGITS;
-    const r2 = row2 % DIGITS;
-    if (r1 === r2) {
-      return;
-    }
-
-    const N = DIGITS;
-    const rows = range(DIGITS).map(i => this._candidates.slice(N*i, N*(i+1)));
-    const digitRows = range(DIGITS).map(i => this._digits.slice(N*i, N*(i+1)));
-    swap(rows, r1, r2);
-    swap(digitRows, r1, r2);
-    this._candidates = rows.flat();
-    this._digits = digitRows.flat();
+    Sudoku.swapRows(this._digits, row1, row2);
+    Sudoku.swapRows(this._candidates, row1, row2);
   }
 
   /**
@@ -1669,22 +1741,8 @@ export class Sudoku {
    * @param {number} col2
    */
   swapColumns(col1, col2) {
-    const c1 = col1 % DIGITS;
-    const c2 = col2 % DIGITS;
-    if (c1 === c2) {
-      return;
-    }
-
-    let temp;
-    for (let r = 0; r < DIGITS; r++) {
-      temp = this._candidates[r * DIGITS + c1];
-      this._candidates[r * DIGITS + c1] = this._candidates[r * DIGITS + c2];
-      this._candidates[r * DIGITS + c2] = temp;
-
-      temp = this._digits[r * DIGITS + c1];
-      this._digits[r * DIGITS + c1] = this._digits[r * DIGITS + c2];
-      this._digits[r * DIGITS + c2] = temp;
-    }
+    Sudoku.swapColumns(this._digits, col1, col2);
+    Sudoku.swapColumns(this._candidates, col1, col2);
   }
 
   /**
@@ -1695,15 +1753,8 @@ export class Sudoku {
    * @param {number} stack2
    */
   swapStacks(stack1, stack2) {
-    const s1 = stack1 % 3;
-    const s2 = stack2 % 3;
-    if (s1 === s2) {
-      return;
-    }
-
-    this.swapColumns(s1*3, s2*3);
-    this.swapColumns(s1*3 + 1, s2*3 + 1);
-    this.swapColumns(s1*3 + 2, s2*3 + 2);
+    Sudoku.swapStacks(this._digits, stack1, stack2);
+    Sudoku.swapStacks(this._candidates, stack1, stack2);
   }
 
   /**

--- a/src/sudoku/Sudoku.js
+++ b/src/sudoku/Sudoku.js
@@ -1925,6 +1925,33 @@ export class Sudoku {
   }
 
   /**
+   * Finds the index of an empty cell that intersects the given mask and contains the fewest candidates.
+   * @param {bigint} mask
+   * @return {number} Cell index, or `-1` if there are no empty cells.
+   */
+  _pickEmptyCellFromMask(mask) {
+    if (this._numEmptyCells === 0) return -1;
+
+    // TODO Keep track of empty cells in state for instant lookup.
+    let min = DIGITS + 1;
+    let _minimums = [];
+    for (let ci = 0; ci < SPACES; ci++) {
+      if (this._digits[ci] === 0 && (mask & cellMask(ci)) > 0) {
+        const numCandidates = BIT_COUNT_MAP[this._candidates[ci]];
+        if (numCandidates === 1) return ci;
+        if (numCandidates < min) {
+          min = numCandidates;
+          _minimums = [ci];
+        } else if (numCandidates === min) {
+          _minimums.push(ci);
+        }
+      }
+    }
+
+    return _minimums.length ? chooseRandom(_minimums) : -1;
+  }
+
+  /**
    * Determines whether this puzzle has a single solution.
    * @returns {boolean} True if the puzzle has a unique solution; otherwise false.
    */

--- a/src/sudoku/Sudoku.js
+++ b/src/sudoku/Sudoku.js
@@ -1161,6 +1161,10 @@ export class Sudoku {
     return this._numEmptyCells;
   }
 
+  get numClues() {
+    return SPACES - this._numEmptyCells;
+  }
+
   /**
    * Returns a mapping of cell indices to a count of how
    * many areas the cell is invalid in.

--- a/src/sudoku/Sudoku.js
+++ b/src/sudoku/Sudoku.js
@@ -241,13 +241,12 @@ export const cellRegion2D = (row, col) => CELL_REGIONS[row * DIGITS + col];
  */
 export function isAreaValid(areaDigits) {
   let reduced = 0;
-  const vals = areaDigits.filter(d => ((d > 0) && (d <= DIGITS)));
-  for (let vi = 0; vi < vals.length; vi++) {
-    const val = encode(vals[vi]);
-    if ((reduced & val) > 0) {
-      return false;
+  for (let d of areaDigits) {
+    if (d > 0 && d <= DIGITS) {
+      const e = encode(d);
+      if ((reduced & e) > 0) return false;
+      reduced |= e;
     }
-    reduced |= val;
   }
   return true;
 }
@@ -277,6 +276,7 @@ class SearchNode {
   }
 
   pickCell() {
+    this.candidates = -1;
     this.emptyCellIndex = this.sudoku._pickEmptyCell();
     if (this.emptyCellIndex != -1) {
       this.candidates = this.sudoku._candidates[this.emptyCellIndex];
@@ -1379,14 +1379,14 @@ export class Sudoku {
    */
   toFullString() {
     return this._digits.reduce((str, val, i) => {
-      str += ((val > 0) ? val : '.');
+      str += val || '.';
       str += (((((i+1)%3) === 0) && (((i+1)%9) !== 0)) ? ' | ' : '   ');
 
       if (((i+1)%9) === 0) {
         str += '\n';
 
         if (i < 80) {
-          str += ((((Math.floor((i+1)/9)%3) == 0) && ((Math.floor(i/9)%8) != 0)) ?
+          str += ((i === 26 || i === 53) ?
             ' -----------+-----------+------------' :
             '            |           |            '
           );

--- a/src/sudoku/Sudoku.js
+++ b/src/sudoku/Sudoku.js
@@ -1835,9 +1835,8 @@ export class Sudoku {
       return false;
     }
 
-    if (isDigit(this._candidates[ci])) {
-      this.setDigit(decode(this._candidates[ci]), ci);
-    }
+    const d = decode(this._candidates[ci]);
+    if (d > 0) this.setDigit(d, ci);
 
     // Propagate to neighboring cells if there was any reduction to the cell.
     if (this._candidates[ci] < originalCandidates) {
@@ -1845,6 +1844,19 @@ export class Sudoku {
         if (this._digits[ni] === 0) this._reduceCell(ni);
       }
     }
+  };
+
+  /**
+   * Attempts to reduce the candidates of the given cell.
+   * Does nothing if the cell contains a digit.
+   * If reducing removes all candidates, marks the sudoku as invalid.
+   * If a single candidate remains, this will NOT set the cell digit.
+   * @param {number} ci cell index
+   */
+  reduceCandidates(ci) {
+    if (this._digits[ci] > 0) return;
+    this._candidates[ci] &= ~this._cellConstraints(ci);
+    if (this._candidates[ci] <= 0) this._isValid = false;
   };
 
   /**


### PR DESCRIPTION
- Adds `sudoku.numClues`
- Adds static functions for swapping bands, stacks, rows, columns
- Scrambler now also performs board rotations
- Adds `sudoku.reduceCandidates(ci)`
- Adds `sudoku._pickEmptyCellFromMask(mask)` which will be used for a puzzle search variant (searching for puzzles given a mask)